### PR TITLE
Support prerelease and skipping head_branch checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ public
 
 # DynamoDB Local files
 .dynamodb/
+
+# Emacs
+*~
+\#*\#
+.#*.*

--- a/src/action.js
+++ b/src/action.js
@@ -121,7 +121,7 @@ function validateBranches(pullRequest) {
       `Releases can only be made against ${expectedBase}. Check your action configuration.`
     );
   }
-  if (head !== expectedHead) {
+  if (expectedHead !== "*" && head !== expectedHead) {
     throw new ValidationError(
       `Releases can only be made from ${expectedHead}. Got ${head}.`
     );

--- a/src/action.js
+++ b/src/action.js
@@ -229,11 +229,14 @@ async function setStatus(pullRequest, state, description) {
 async function release(pullRequest) {
   core.info(`Releasing ${pullRequest.merge_commit_sha}..`);
   const tag = getTagName(pullRequest);
+  const isPrerelease = JSON.parse(core.getInput("prerelease") || false) === true;
+  core.info(`Is prerelease? ${isPrerelease}`);
+
   await client.repos.createRelease({
     name: pullRequest.title,
     tag_name: tag,
     body: pullRequest.body,
-    prerelease: false,
+    prerelease: isPrerelease,
     draft: false,
     target_commitish: pullRequest.merge_commit_sha,
     ...github.context.repo

--- a/src/action.js
+++ b/src/action.js
@@ -229,7 +229,8 @@ async function setStatus(pullRequest, state, description) {
 async function release(pullRequest) {
   core.info(`Releasing ${pullRequest.merge_commit_sha}..`);
   const tag = getTagName(pullRequest);
-  const isPrerelease = JSON.parse(core.getInput("prerelease") || false) === true;
+  const isPrerelease =
+    JSON.parse(core.getInput("prerelease") || false) === true;
   core.info(`Is prerelease? ${isPrerelease}`);
 
   await client.repos.createRelease({


### PR DESCRIPTION
- Allow `prerelease` as an optional attr to mark release as prerelease
- Allow skipping head_branch validation by setting it to `*` (`null` seems to be the same as attr being unset, and it's probably best to keep it a required input, but allow skipping it explicitly.)