### PR TITLE
 Support prerelease and skipping head_branch checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - master
   push:
-    branches:
-      - master
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ public
 
 # DynamoDB Local files
 .dynamodb/
+
+# Emacs
+*~
+\#*\#
+.#*.*

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: 'If release reviews should be approved or just commented upon'
     required: true
     default: true
+  prerelease:
+    description: 'Creates a prerelease instead of release'
+    required: false
+    default: false
+  validate:
+    description: 'Validate title and description of pull request'
+    required: false
+    default: true
   release_label:
     description: 'Label to add to release PR.'
     default: 'release'

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
       'Pattern to validate title against.
        If it contains any of the named capture groups <year>, <month>, <day> calver validation will occur.'
     required: true
-    default: '^(?<year>[0-9]{4})\.(?<month>[0-9]{2})\.(?<day>[0-9]{2})-\d$'
+    default: '^(?<year>[0-9]{4})\.(?<month>[0-9]{2})\.(?<day>[0-9]{2})-\d+$'
   tag_prefix:
     description: 'Prefix to use when tagging release'
     required: true

--- a/src/action.js
+++ b/src/action.js
@@ -13,6 +13,7 @@ async function action() {
     return;
   }
   const validateActions = ["opened", "edited", "reopened"];
+
   if (validateActions.includes(action)) {
     // Run validation for accepted actions
     core.info(`Validating pull request for action ${action}.`);
@@ -32,6 +33,12 @@ async function action() {
 }
 
 async function validate(pullRequest) {
+  const doValidate = JSON.parse(core.getInput("validate") || true) === true;
+
+  if (!doValidate) {
+    return pullRequest;
+  }
+
   try {
     // Add release label
     await addLabel(pullRequest);
@@ -231,8 +238,8 @@ async function release(pullRequest) {
   const tag = getTagName(pullRequest);
   const isPrerelease =
     JSON.parse(core.getInput("prerelease") || false) === true;
-  core.info(`Is prerelease? ${isPrerelease}`);
 
+  core.info(`Is prerelease? ${isPrerelease}`);
   await client.repos.createRelease({
     name: pullRequest.title,
     tag_name: tag,

--- a/src/action.js
+++ b/src/action.js
@@ -229,11 +229,14 @@ async function setStatus(pullRequest, state, description) {
 async function release(pullRequest) {
   core.info(`Releasing ${pullRequest.merge_commit_sha}..`);
   const tag = getTagName(pullRequest);
+  const isPrerelease = JSON.parse(core.getInput("prerelease") || false) === true;
+  core.info(`Is prerelease? ${isPrerelease}`);
+
   await client.repos.createRelease({
     name: pullRequest.title,
     tag_name: tag,
     body: pullRequest.body,
-    prerelease: false,
+    prerelease: isPrerelease,
     draft: false,
     target_commitish: pullRequest.merge_commit_sha,
     ...github.context.repo

--- a/src/action.js
+++ b/src/action.js
@@ -45,7 +45,7 @@ async function validate(pullRequest) {
     await validateRelease(pullRequest);
   } catch (error) {
     if (error.name === "ValidationError") {
-      core.error("Failed validation.");
+      core.error(`Failed validation. Message: ${error.message}`);
       // Review if error is a ValidationError
       await review(pullRequest, getReviewFailEvent(), error.message);
     }
@@ -121,7 +121,7 @@ function validateBranches(pullRequest) {
       `Releases can only be made against ${expectedBase}. Check your action configuration.`
     );
   }
-  if (head !== expectedHead) {
+  if (expectedHead !== "*" && head !== expectedHead) {
     throw new ValidationError(
       `Releases can only be made from ${expectedHead}. Got ${head}.`
     );
@@ -229,7 +229,8 @@ async function setStatus(pullRequest, state, description) {
 async function release(pullRequest) {
   core.info(`Releasing ${pullRequest.merge_commit_sha}..`);
   const tag = getTagName(pullRequest);
-  const isPrerelease = JSON.parse(core.getInput("prerelease") || false) === true;
+  const isPrerelease =
+    JSON.parse(core.getInput("prerelease") || false) === true;
   core.info(`Is prerelease? ${isPrerelease}`);
 
   await client.repos.createRelease({


### PR DESCRIPTION

- Add support for marking new release as pre-release. Optional attribute, defaulting to prerelease: false when not set
- Allow skipping head_branch validation for PR. Setting it as null is the same as not setting it at all. I think it's better to keep it required, and allow for explicitly setting it to something (now it's a *) to allow any head branch.
- Minor fix on default release pattern regex to accept multi-digit for release number after date. If this was intended, I can revert and set specifically on my action.
