### PR TITLE
Transform tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Defaults to `^(?<year>[0-9]{4})\.(?<month>[0-9]{2})\.(?<day>[0-9]{2})-\d$`.
 
 The prefix to use when tagging release. Set to null or an empty string to disable tag-prefixing. Defaults to `releases/`.
 
+### `tag_transformer`
+
+Apply a transform on the tag before validating and releasing it.
+Available choices: "title", "dashes-and-number".
+
+The default is `title`, which supplies the PR title as is.
+
+When using `dashes-and-number`, a PR with number 32 and title "Fix thing" becomes `#32-fix-thing`.
+
 ### `approve_releases`
 
 Sets if a PR should just be commented upon or approved and request changes depending on the success of validation. Accepts `true` or `false`. Defaults to `true` .

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: 'Validate title and description of pull request'
     required: false
     default: true
+  tag_transformer:
+    description: 'Transformer to use to change the tag name.'
+    required: false
+    default: 'title'
   release_label:
     description: 'Label to add to release PR.'
     default: 'release'

--- a/dist/index.js
+++ b/dist/index.js
@@ -216,10 +216,25 @@ async function validateRelease(pullRequest) {
   throw new ValidationError("Release tag already exists.");
 }
 
+const TRANSFORMERS = {
+  "dashes-and-number": ({ title, number }) => {
+    const name = title
+      .replace(/\s+/g, "-")
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]/g, "");
+    return `#${number}-${name}`;
+  },
+  title: ({ title }) => title
+};
+
 function getTagName(pullRequest) {
-  const { title } = pullRequest;
   const tagPrefix = core.getInput("tag_prefix", { required: true });
-  return tagPrefix + title;
+  const transformerName = core.getInput("tag_transformer");
+  const transformer = TRANSFORMERS[transformerName || "title"];
+  if (!transformer) {
+    throw Error(`Invalid transformer: ${transformerName}`);
+  }
+  return tagPrefix + transformer(pullRequest);
 }
 
 async function addLabel(pullRequest) {
@@ -356,7 +371,7 @@ const { action } = __webpack_require__(182);
 
 action().catch(error => {
   // Action threw an error. Fail the action with the error message.
-  core.setFailed(error.message);
+  core.setFailed(`${error.message} ${JSON.stringify(error)}`);
 });
 
 

--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ const { action } = require("./src/action");
 
 action().catch(error => {
   // Action threw an error. Fail the action with the error message.
-  core.setFailed(error.message);
+  core.setFailed(`${error.message} ${JSON.stringify(error)}`);
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node ./index.js",
     "test": "jest --collectCoverage",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "repository": {
     "type": "git",

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -8,6 +8,7 @@ const repo = "somerepo";
 beforeEach(() => {
   process.env["INPUT_REPO_TOKEN"] = "hunter2";
   process.env["GITHUB_REPOSITORY"] = `${owner}/${repo}`;
+  process.env["INPUT_TAG_TRANSFORMER"] = "title";
 });
 
 test("validate", async () => {
@@ -115,7 +116,22 @@ test("getTagName", () => {
   const { getTagName } = require("./action");
 
   process.env["INPUT_TAG_PREFIX"] = "release/";
-  expect(getTagName({ title: "hejhej" })).toBe("release/hejhej");
+  expect(getTagName({ title: "hejhej", number: 32 })).toBe("release/hejhej");
+
+  process.env["INPUT_TAG_TRANSFORMER"] = "dashes-and-number";
+  expect(getTagName({ title: "This is a PR", number: 32 })).toBe(
+    "release/#32-this-is-a-pr"
+  );
+});
+
+test("getTagName errors for bad transformers", () => {
+  const { getTagName } = require("./action");
+
+  process.env["INPUT_TAG_PREFIX"] = "release/";
+  process.env["INPUT_TAG_TRANSFORMER"] = "bad transformer";
+  expect(() => getTagName({ title: "hejhej", number: 32 })).toThrow(
+    /Invalid transformer: bad transformer/
+  );
 });
 
 test("addLabel", async () => {


### PR DESCRIPTION
This enables no-validation (pre-release / dev) flows where the tag is automatically generated from the PR title.
PR # 3 with title "Fix issue with thing" becomes `release/#3-fix-issue-with-thing`

~Also I'm removing `node_modules`. Hopefully that's OK.~ Looks like it might be there for cache'ing? Maybe it should be updated in that case?


**TODO**

- [x] Revert change of const to let 