### PR TITLE
Allow <year> tag being 2 integers i.e. short year

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8365,7 +8365,8 @@ function validateTitle(pullRequest) {
   // Check year
   if (
     releasePattern.includes("<year>") &&
-    today.getUTCFullYear() !== Number(year)
+    today.getUTCFullYear() !== Number(year) &&
+    Number(today.getUTCFullYear().toString().substr(-2)) !== Number(year)
   ) {
     throw new ValidationError(
       `${year} is not a valid year. Current is ${today.getUTCFullYear()}.`

--- a/src/action.js
+++ b/src/action.js
@@ -87,7 +87,8 @@ function validateTitle(pullRequest) {
   // Check year
   if (
     releasePattern.includes("<year>") &&
-    today.getUTCFullYear() !== Number(year)
+    today.getUTCFullYear() !== Number(year) &&
+    Number(today.getUTCFullYear().toString().substr(-2)) !== Number(year)
   ) {
     throw new ValidationError(
       `${year} is not a valid year. Current is ${today.getUTCFullYear()}.`

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -238,6 +238,14 @@ test("validateTitle", () => {
   expect(() => {
     validateTitle({ title: "IAMINVALID" });
   }).toThrow(/Invalid release title/);
+
+  // Valid as short year
+  process.env["INPUT_RELEASE_PATTERN"] =
+    "^(?<year>[0-9]{2})\\.(?<month>[0-9]{2})\\.\\d$";
+  validateTitle({ title: moment.utc(new Date()).format("YY.MM.1") });
+  expect(() => {
+    validateTitle({ title: "20.12.1" });
+  }).toThrow(/is not a valid year/);
 });
 
 test("validateBody", () => {


### PR DESCRIPTION
Allows a `release_pattern` being declared as: `^(?<year>[0-9]{2})\.(?<month>[0-9]{2})\.\d+$`

A pattern like this would currently fail with:

```
Validating title 21.12.1 against pattern ^(?<year>[0-9]{2})\.(?<month>[0-9]{2})\.\d+$
Error: Failed validation. Message: 21 is not a valid year. Current is 2021.
```