### PR TITLE
Remove trailing dashes in tag names

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8443,7 +8443,8 @@ const TRANSFORMERS = {
       .trim()
       .replace(/\s+/g, "-")
       .toLowerCase()
-      .replace(/[^a-z0-9-_]/g, "");
+      .replace(/[^a-z0-9_]/g, "")
+      .replace(/-+$/g, "");
     return `#${number}-${name}`;
   },
   title: ({ title }) => title,

--- a/src/action.js
+++ b/src/action.js
@@ -165,7 +165,8 @@ const TRANSFORMERS = {
       .trim()
       .replace(/\s+/g, "-")
       .toLowerCase()
-      .replace(/[^a-z0-9-_]/g, "");
+      .replace(/[^a-z0-9-_]/g, "")
+      .replace(/-+$/g, "");
     return `#${number}-${name}`;
   },
   title: ({ title }) => title,

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -119,7 +119,7 @@ test("getTagName", () => {
   expect(getTagName({ title: "hejhej", number: 32 })).toBe("release/hejhej");
 
   process.env["INPUT_TAG_TRANSFORMER"] = "dashes-and-number";
-  expect(getTagName({ title: "This is a PR", number: 32 })).toBe(
+  expect(getTagName({ title: "This is a PR---", number: 32 })).toBe(
     "release/#32-this-is-a-pr"
   );
 


### PR DESCRIPTION
Git allows them, but not Github